### PR TITLE
Lowercase name and provide git clone urls.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,8 @@
 ---
-name : "Hooligan"
+name : "hooligan"
 website :  "https://github.com/dhulihan/hooligan"
+git_url : "https://github.com/dhulihan/hooligan.git"
+source_url : "https://github.com/dhulihan/hooligan"
 description :  "A random theme for Jekyll + Jekyll-Bootstrap."
 author:
   name : "Dave Hulihan"


### PR DESCRIPTION
Lowercase is just to stick to conventions. I was having trouble with the paths initially.

git clone urls allow users to click on "install theme" for instructions on http://themes.jekyllbootstrap.com
