### PR TITLE
The default layout was missing the feedburner link and icon in the nav bar

### DIFF
--- a/_includes/themes/hooligan/default.html
+++ b/_includes/themes/hooligan/default.html
@@ -85,6 +85,11 @@
                   <a href="http://www.linkedin.com/in/{{ site.author.linkedin }}" class="zocial linkedin icon" target="_blank"></a>
                 </li>
               {% endif %}                    
+              {% if site.author.feedburner %}
+                <li>
+                  <a href="http://feeds.feedburner.com/{{ site.author.feedburner }}" class="zocial rss icon" target="_blank"></a>
+                </li>
+              {% endif %}
             </ul>
           </div>
         </div>


### PR DESCRIPTION
The README mentions that in the _config.yml file you can specify a configuration flag called "feedburner" that will add a new social button to the top nav bar for rss / feedburner. But if if you do specify this in the config the button never makes it to the nav bar because the code is missing from "default.html".

This commit just adds that missing code block.
