### PR TITLE
set the copyright to the current year

### DIFF
--- a/_includes/themes/hooligan/default.html
+++ b/_includes/themes/hooligan/default.html
@@ -114,7 +114,7 @@
       </div>
 
       <footer>
-        <p>&copy; {{ site.author.name }} 2012 
+        <p>&copy; {{ site.author.name }} {{ site.time | date: '%Y' }}
           with help from <a href="http://jekyllbootstrap.com" target="_blank" title="The Definitive Jekyll Blogging Framework">Jekyll Bootstrap</a>
           and <a href="http://github.com/dhulihan/hooligan" target="_blank">The Hooligan Theme</a>
         </p>


### PR DESCRIPTION
It was hardcoded to 2012, which looked odd when I made a post this year; instead make it use the year jekyll is doing the generate
