### PR TITLE
Add Updated section to posts

### DIFF
--- a/_includes/themes/hooligan/post.html
+++ b/_includes/themes/hooligan/post.html
@@ -32,6 +32,10 @@
     <section>
       <h4>Published</h4>
       <div class="date"><span>{{ page.date | date_to_long_string }}</span></div>
+      {% if page.updated %}
+      <h4>Updated</h4>
+      <div class="date"><span>{{ page.updated | date_to_long_string }}</span></div>
+      {% endif %}     
     </section>
     {% if page.category %}
       <section>


### PR DESCRIPTION
Added an "Updated" section at right beneath "Published" which only shows when front matter contains an "updated" field.

![image](https://cloud.githubusercontent.com/assets/4093/7338520/1fa5818e-ec03-11e4-9dda-65186b59e414.png)
