### PR TITLE
Show multiple categories when present

### DIFF
--- a/_includes/themes/hooligan/post.html
+++ b/_includes/themes/hooligan/post.html
@@ -33,12 +33,14 @@
       <h4>Published</h4>
       <div class="date"><span>{{ page.date | date_to_long_string }}</span></div>
     </section>
-    {% if page.category %}
+    {% if page.categories %}
       <section>
-        <h4>Category</h4>
+        <h4>{% if page.categories.size == 1 %}Category{% else %}Categories{% endif %}</h4>
+        {% for category in page.categories %}
         <span class="category">
-          {{ page.category }}
+          {{ category }}
         </span>
+        {% endfor %}
       </section>
     {% endif %}     
     {% unless page.tags == empty %}


### PR DESCRIPTION
Switched to using page.categories and use proper singular/plural on section name.

I don't love the if/else enclosing "Category" and "Categories" but don't have a more elegant form short of a liquid extension.

![image](https://cloud.githubusercontent.com/assets/4093/7338817/e7c9c5a4-ec0c-11e4-9436-9356b14dc61f.png)

![image](https://cloud.githubusercontent.com/assets/4093/7338820/f3d8a86a-ec0c-11e4-8446-9ec1e3fa9661.png)
